### PR TITLE
Implement friendsofcakephp search plugin on activities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "cakephp/cakephp": "~4.2.0",
         "cakephp/migrations": "^3.0",
         "cakephp/plugin-installer": "^1.3",
+        "friendsofcake/search": "^6.2",
         "league/oauth1-client": "@stable",
         "mobiledetect/mobiledetectlib": "^2.8",
         "thenetworg/oauth2-azure": "^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "db972f85b7edf3e2b66b45db6652c8e3",
+    "content-hash": "6657a824490c849d274f98d32fa4d714",
     "packages": [
         {
             "name": "cakedc/auth",
@@ -691,6 +691,65 @@
                 "source": "https://github.com/firebase/php-jwt/tree/v5.2.1"
             },
             "time": "2021-02-12T00:02:00+00:00"
+        },
+        {
+            "name": "friendsofcake/search",
+            "version": "6.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfCake/search.git",
+                "reference": "67aaee581c712ca344a2c8dab3015237324eaf6e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfCake/search/zipball/67aaee581c712ca344a2c8dab3015237324eaf6e",
+                "reference": "67aaee581c712ca344a2c8dab3015237324eaf6e",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/cakephp": "^4.0"
+            },
+            "require-dev": {
+                "cakephp/bake": "^2.3",
+                "cakephp/cakephp-codesniffer": "^4.0",
+                "cakephp/twig-view": "^1.1.1",
+                "muffin/webservice": "^3.0@beta",
+                "phpunit/phpunit": "~8.5.0"
+            },
+            "type": "cakephp-plugin",
+            "autoload": {
+                "psr-4": {
+                    "Search\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Winther",
+                    "role": "Author"
+                },
+                {
+                    "name": "ADmad",
+                    "homepage": "https://github.com/admad",
+                    "role": "Contributor"
+                }
+            ],
+            "description": "CakePHP Search plugin using PRG pattern",
+            "homepage": "https://github.com/FriendsOfCake/search",
+            "keywords": [
+                "cakephp",
+                "filter",
+                "prg",
+                "search"
+            ],
+            "support": {
+                "issues": "https://github.com/FriendsOfCake/search/issues",
+                "source": "https://github.com/FriendsOfCake/search"
+            },
+            "time": "2021-02-18T18:03:30+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/src/Application.php
+++ b/src/Application.php
@@ -66,6 +66,7 @@ class Application extends BaseApplication
 
         // Load more plugins here
         $this->addPlugin(\CakeDC\Users\Plugin::class);
+        $this->addPlugin('Search');
     }
 
     /**

--- a/src/Controller/ActivitiesController.php
+++ b/src/Controller/ActivitiesController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 
 Use Cake\ORM\TableRegistry;
 use Cake\Utility\Text;
+use Cake\Event\EventInterface;
 
 /**
  * Activities Controller
@@ -14,6 +15,16 @@ use Cake\Utility\Text;
  */
 class ActivitiesController extends AppController
 {
+    
+    public function initialize(): void
+    {
+        parent::initialize();
+
+        $this->loadComponent('Search.Search', [
+            'actions' => ['search'],
+        ]);
+    }
+
     /**
      * Index method
      *
@@ -232,25 +243,10 @@ class ActivitiesController extends AppController
      */
     public function find()
     {
-
-	    $search = $this->request->getQuery('q');
-        $activities = $this->Activities->find()->
-                                        contain('Steps.Pathways','ActivityTypes')->
-                                        where(function ($exp, $query) use($search) {
-            return $exp->like('name', '%'.$search.'%');
-        })->order(['name' => 'ASC']);
-        $activities = $this->Activities->find()->
-                                            contain('Steps.Pathways','ActivityTypes')->
-                                            where(function ($exp, $query) use($search) {
-                                                return $exp->like('description', '%'.$search.'%');
-                                            })->
-                                            order(['name' => 'ASC']);
+        $activities = $this->Activities->find('search', ['search' => $this->request->getQuery()]);
+        $search = $this->request->getQuery('search');
         $numresults = $activities->count();
-        $allpaths = TableRegistry::getTableLocator()->get('Pathways');
-        $pathways = $allpaths->find('all')->contain(['Steps']);
-        $allpathways = $pathways->toList();
-        
-        $this->set(compact('activities','allpathways','search', 'numresults'));
+        $this->set(compact('activities','search', 'numresults'));
     }
     /**
      * Find method for activities; intended for use as an auto-complete

--- a/src/Model/Table/ActivitiesTable.php
+++ b/src/Model/Table/ActivitiesTable.php
@@ -108,6 +108,21 @@ class ActivitiesTable extends Table
             'joinTable' => 'activities_tags',
         ]);
 
+        $this->addBehavior('Search.Search');
+
+	    $this->searchManager()
+                ->value('name')
+                ->value('description')
+                ->add('search', 'Search.Like', [ 
+                    'before' => true,
+                    'after' => true,
+                    'fieldMode' => 'OR',
+                    'comparison' => 'LIKE',
+                    'wildcardAny' => '*',
+                    'wildcardOne' => '?',
+                    'fields' => ['name','description'],
+                ]);
+
     }
 
     /**

--- a/templates/Activities/find.php
+++ b/templates/Activities/find.php
@@ -16,7 +16,7 @@ if ($this->Identity->isLoggedIn()) {
 <div>Found <span class="badge badge-dark"><?= $numresults ?></span> activities</div>
 <div class="py-3">
 	<form method="get" action="/activities/find" class="form-inline">
-		<input class="form-control mr-sm-2" type="search" placeholder="Search again" aria-label="Search" name="q">
+		<input class="form-control mr-sm-2" type="search" placeholder="Search again" aria-label="Search" name="search">
 		<button class="btn btn-outline-dark my-2 my-sm-0" type="submit">Search</button>
 	</form>
 </div>

--- a/templates/layout/default.php
+++ b/templates/layout/default.php
@@ -115,7 +115,7 @@ $this->loadHelper('Authentication.Identity');
 		<?php endif ?>
 	</ul>
 	<form method="get" action="/activities/find" class="form-inline my-2 my-lg-0 mr-3">
-		<input class="form-control mr-sm-2" type="search" placeholder="Activity Search" aria-label="Search" name="q">
+		<input class="form-control mr-sm-2" type="search" placeholder="Activity Search" aria-label="Search" name="search">
 		<button class="btn btn-outline-dark my-2 my-sm-0" type="submit">Search</button>
 	</form>
 


### PR DESCRIPTION
Adds and implements: https://github.com/FriendsOfCake/search
"Search provides a simple interface to create paginate-able filters for your CakePHP application"
This is currently only implemented on the activities model, but now that it's installed, we can extend it to other models as well.
This issue is currently waaaay down on the product backlog, but I came across a how-to in my travels and just went with it because it's been hanging over the project and been punted on a few times, so I took the opportunity and ran with it! We now have decent-enough and expandable model search capabilities, so huzzah!